### PR TITLE
Fix formatRoutes exposure 

### DIFF
--- a/lib/socket-hook.js
+++ b/lib/socket-hook.js
@@ -155,7 +155,7 @@ function addParam(param, value, requestData) {
 
 module.exports = SocketHook;
 
-module.exports.formatRoutes = function formatRoutes(loopbackApplication, typeRegistry) {
+var formatRoutes = function formatRoutes(loopbackApplication, typeRegistry) {
   var result = new Array();
 
   var remotes = loopbackApplication.remotes();
@@ -182,4 +182,6 @@ module.exports.formatRoutes = function formatRoutes(loopbackApplication, typeReg
   });
 
   return result;
-}
+};
+
+module.exports.formatRoutes = formatRoutes;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-hook-socket",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Receive response from Loopback REST API over socket.io",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Linked to https://github.com/Vatrushkin/loopback-hook-socket/issues/2

The function "formatRoutes" needs to first be defined internally within the scope of socket-hook.js (& then attached to exports). It is currently defined directly at exports.

It creates a parse error.

This pull request fixes the issue.
